### PR TITLE
fix: ajoute une variable d'env `MAX_CONNECTION_IDLE_TIME_MILLIS` pour…

### DIFF
--- a/bin/custom-startup-scripts/connections-http-client.cli
+++ b/bin/custom-startup-scripts/connections-http-client.cli
@@ -1,0 +1,1 @@
+/subsystem=keycloak-server/spi=connectionsHttpClient/provider=default:write-attribute(name=properties.max-connection-idle-time-millis, value=${env.MAX_CONNECTION_IDLE_TIME_MILLIS:180000})

--- a/bin/startup-scripts/standalone-configuration.cli
+++ b/bin/startup-scripts/standalone-configuration.cli
@@ -1,4 +1,5 @@
 embed-server --server-config=standalone.xml --std-out=echo
 run-batch --file= /opt/jboss/custom-startup-scripts/log.cli
 run-batch --file= /opt/jboss/custom-startup-scripts/datasource-pool.cli
+run-batch --file= /opt/jboss/custom-startup-scripts/connections-http-client.cli
 stop-embedded-server

--- a/bin/startup-scripts/standalone-ha-configuration.cli
+++ b/bin/startup-scripts/standalone-ha-configuration.cli
@@ -1,4 +1,6 @@
 embed-server --server-config=standalone-ha.xml --std-out=echo
 run-batch --file= /opt/jboss/custom-startup-scripts/log.cli
 run-batch --file= /opt/jboss/custom-startup-scripts/datasource-pool.cli
+run-batch --file= /opt/jboss/custom-startup-scripts/connections-http-client.cli
+
 stop-embedded-server


### PR DESCRIPTION
… changer la durée max de maintien des sockets tcp inactifs. defaut 3min